### PR TITLE
Add explanation for integer overflow example

### DIFF
--- a/benchmarks/suhabe/integer_overflow_add.rst
+++ b/benchmarks/suhabe/integer_overflow_add.rst
@@ -1,0 +1,14 @@
+Integer Overflow (state modifying)
+==================================
+
+.. literalinclude:: integer_overflow_add.sol
+
+This is an example of an integer overflow bug that allows an attacker to directly set an overflow condition
+and let them set the value of ``count`` to whatever they want.
+In the original specification, the developer of this application might have intended that ``count`` would allow
+be allowed to be incremented from it's previous number (for example, in minting new tokens).
+
+However, due to this vulnerability the attacker is able to set ``count`` to 0 by sending ``MAX_UINT256 - 1``
+(which is ``2**256 - 2``) for the argument ``input``, which is at the very least unintended behavior.
+
+More extreme versions of this bug were the basis for the following public mainnet explots: [DB_ENTRY], etc.


### PR DESCRIPTION
If this type of explanation were added for all files in this listing of bugs, we could create a website that could be referenced for deeper understanding on the mechanisms behind these vulnerabilities and how they work.